### PR TITLE
chore: add root export entry and module/types fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,47 @@
 {
   "name": "archstone",
+  "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
   "version": "1.0.2",
   "type": "module",
   "private": false,
-  "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
+  "files": [
+    "dist"
+  ],
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./core": {
+      "import": {
+        "types": "./dist/core/index.d.ts",
+        "default": "./dist/core/index.js"
+      }
+    },
+    "./domain": {
+      "import": {
+        "types": "./dist/domain/index.d.ts",
+        "default": "./dist/domain/index.js"
+      }
+    },
+    "./domain/application": {
+      "import": {
+        "types": "./dist/domain/application/index.d.ts",
+        "default": "./dist/domain/application/index.js"
+      }
+    },
+    "./domain/enterprise": {
+      "import": {
+        "types": "./dist/domain/enterprise/index.d.ts",
+        "default": "./dist/domain/enterprise/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "keywords": [
     "ddd",
     "domain-driven-design",
@@ -30,36 +68,6 @@
   },
   "bugs": {
     "url": "https://github.com/joao-coimbra/archstone/issues"
-  },
-  "files": [
-    "dist"
-  ],
-  "exports": {
-    "./core": {
-      "import": {
-        "types": "./dist/core/index.d.ts",
-        "default": "./dist/core/index.js"
-      }
-    },
-    "./domain": {
-      "import": {
-        "types": "./dist/domain/index.d.ts",
-        "default": "./dist/domain/index.js"
-      }
-    },
-    "./domain/application": {
-      "import": {
-        "types": "./dist/domain/application/index.d.ts",
-        "default": "./dist/domain/application/index.js"
-      }
-    },
-    "./domain/enterprise": {
-      "import": {
-        "types": "./dist/domain/enterprise/index.d.ts",
-        "default": "./dist/domain/enterprise/index.js"
-      }
-    },
-    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "bunup",


### PR DESCRIPTION
## Summary
- Adds a root `.` export pointing to `dist/index.js` / `dist/index.d.ts`
- Adds top-level `module` and `types` fields for broader tooling compatibility
- Reorders `package.json` fields for consistency

## Test Plan
- [ ] `bun test` passes
- [ ] `bun run build` produces correct dist output
- [ ] Root import `import { ... } from 'archstone'` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)