### PR TITLE
chore: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint
+        run: bun x ultracite check
+
+      - name: Test
+        run: bun test


### PR DESCRIPTION
## Summary
- Adds CI workflow that runs on every push and PR to `master`
- Runs `ultracite check` (lint) and `bun test` on ubuntu-latest
- Uses `oven-sh/setup-bun@v2` for Bun setup

## Test Plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)