### PR TITLE
docs: add top spacing to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<br />
+
 # Archstone
 
 ### The TypeScript foundation for serious backend services.


### PR DESCRIPTION
Adds a `<br />` before the title to prevent the header from feeling cramped.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>