### PR TITLE
chore: publish v1.1.0 with agent skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archstone",
   "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
## Summary
- Add `skills/` to `"files"` in package.json so agent skills ship with the package
- Bump version to v1.1.0 (minor — new feature: agent skills)

## What this enables
- After `bun add archstone`, skills are available at `node_modules/archstone/skills/archstone/`
- Can also be installed directly via `bun x skills add joao-coimbra/archstone`