### PR TITLE
fix: use bunx husky in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "check": "ultracite check",
     "fix": "ultracite fix",
     "prepublishOnly": "bun run build",
-    "prepare": "husky"
+    "prepare": "bunx husky"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.5",


### PR DESCRIPTION
## Summary
- Change `"prepare": "husky"` to `"prepare": "bunx husky"` so the local binary is always resolved correctly during `bun publish`

## Why
`bun publish` runs the `prepare` lifecycle hook and `husky` wasn't found in PATH since it's a devDependency. Using `bunx` resolves it from `node_modules/.bin/`.