### PR TITLE
fix: use bunx husky in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "check": "ultracite check",
     "fix": "ultracite fix",
     "prepublishOnly": "bun run build",
-    "prepare": "husky"
+    "prepare": "bunx husky"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.5",


### PR DESCRIPTION
bun publish does not add node_modules/.bin to PATH during lifecycle scripts, causing husky to be not found. Using bunx resolves the binary correctly.