### PR TITLE
docs: bump to v1.1.1 to sync README on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archstone",
   "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Patch bump to publish the updated README to the npm package page. No code changes.