### PR TITLE
feat: add release workflow with dist zip artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Create dist zip
+        run: zip -r archstone-${{ github.ref_name }}-dist.zip dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_from_tag: true
+          files: archstone-${{ github.ref_name }}-dist.zip


### PR DESCRIPTION
On every `v*` tag push, this workflow:
1. Installs dependencies and builds
2. Zips `dist/` into `archstone-vX.X.X-dist.zip`
3. Creates a GitHub Release using the annotated tag message as description
4. Attaches the zip as a downloadable release asset