### PR TITLE
fix: remove -dist suffix from release zip filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun run build
 
       - name: Create dist zip
-        run: zip -r archstone-${{ github.ref_name }}-dist.zip dist/
+        run: zip -r archstone-${{ github.ref_name }}.zip dist/
 
       - name: Get tag message
         id: tag_message
@@ -37,4 +37,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ steps.tag_message.outputs.body }}
-          files: archstone-${{ github.ref_name }}-dist.zip
+          files: archstone-${{ github.ref_name }}.zip


### PR DESCRIPTION
Rename artifact from archstone-vX.X.X-dist.zip to archstone-vX.X.X.zip for cleaner release assets.