### PR TITLE
fix: enable code splitting and minify in bunup config

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -13,5 +13,7 @@ export default defineConfig({
   target: "bun",
   dts: true,
   clean: true,
+  splitting: true,
+  minify: true,
   plugins: [exports()],
 })


### PR DESCRIPTION
## Summary

- Adds `splitting: true` and `minify: true` to `bunup.config.ts`

## Why

Each sub-path (`archstone/core`, `archstone/domain/enterprise`, etc.) was compiled as a standalone bundle, producing duplicate copies of shared types like `UniqueEntityId`. Since the class has a `private value` field, TypeScript uses nominal typing and treats the two copies as incompatible — causing:

> *Types have separate declarations of a private property 'value'*

when mixing imports from different sub-paths.

With `splitting: true`, the bundler extracts shared code into a single chunk that all sub-paths import from, ensuring a single declaration of each type across the entire package.

## Test plan

- [ ] `bun run build` produces a shared chunk file
- [ ] Importing from multiple sub-paths in a consumer project no longer triggers the private property conflict error

🤖 Generated with [Claude Code](https://claude.com/claude-code)