### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archstone",
   "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
## Summary

- Bumps version from `1.1.2` to `1.2.0`
- Follows the fix for bundle splitting that caused type conflicts with private fields across sub-paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)