### PR TITLE
fix: resolve dts type conflict across sub-path entry points

### DIFF
--- a/bunup.config.ts
+++ b/bunup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   ],
   format: ["esm"],
   target: "bun",
-  dts: true,
+  dts: { splitting: true },
   clean: true,
   splitting: true,
   minify: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archstone",
   "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
-  "version": "1.2.0",
+  "version": "1.2.1-rc.0",
   "type": "module",
   "private": false,
   "files": [

--- a/src/domain/application/use-cases/use-case.ts
+++ b/src/domain/application/use-cases/use-case.ts
@@ -1,4 +1,4 @@
-import type { Either } from "@/core/either.ts"
+import type { Either } from "@/core/index.ts"
 import type { UseCaseError } from "./use-case.error.ts"
 
 /**

--- a/src/domain/enterprise/entities/entity.ts
+++ b/src/domain/enterprise/entities/entity.ts
@@ -1,4 +1,4 @@
-import { UniqueEntityId } from "@/core/unique-entity-id.ts"
+import { UniqueEntityId } from "@/core/index.ts"
 
 /**
  * Base class for all domain entities.

--- a/src/domain/enterprise/events/domain-event.ts
+++ b/src/domain/enterprise/events/domain-event.ts
@@ -1,4 +1,4 @@
-import type { UniqueEntityId } from "@/core/unique-entity-id.ts"
+import type { UniqueEntityId } from "@/core/index.ts"
 
 /**
  * Base contract for all domain events.

--- a/src/domain/enterprise/events/domain-events.ts
+++ b/src/domain/enterprise/events/domain-events.ts
@@ -1,4 +1,4 @@
-import type { UniqueEntityId } from "@/core/unique-entity-id.ts"
+import type { UniqueEntityId } from "@/core/index.ts"
 import type { AggregateRoot } from "../entities/aggregate-root.ts"
 import type { DomainEvent } from "./domain-event.ts"
 


### PR DESCRIPTION
## Problem

When importing from multiple sub-paths (`archstone/core` + `archstone/domain/enterprise`), TypeScript throws:

> *Types have separate declarations of a private property 'value'*

Each sub-path bundle was independently inlining shared types like `UniqueEntityId` into its own `.d.ts`, so TypeScript's nominal typing saw two incompatible class declarations.

## Fix

**1. Redirect deep core imports to entry-point indices**

Source files were importing from deep paths (`@/core/unique-entity-id.ts`, `@/core/either.ts`) that bunup doesn't recognise as entry-point boundaries. Changed to entry-point imports (`@/core/index.ts`) so the dts bundler knows these types belong to the `core` bundle:

- `entity.ts` — `UniqueEntityId`
- `domain-event.ts` — `UniqueEntityId`
- `domain-events.ts` — `UniqueEntityId`
- `use-case.ts` — `Either`

**2. Enable `dts.splitting`**

Shared types are now extracted into `dist/shared/*.d.ts` chunks and imported by all sub-path entry `.d.ts` files — a single declaration per type across the entire package.

## Result

| File | Before | After |
|------|--------|-------|
| `dist/domain/enterprise/index.d.ts` | 7.77 KB (inline) | 229 B (re-export) |
| `dist/core/index.d.ts` | 6.63 KB | 203 B (re-export) |
| `dist/shared/chunk-*.d.ts` | — | shared type chunks |

Published as `archstone@1.2.1-rc.0` for testing before full release.

## Test plan

- [ ] `bun test` passes
- [ ] Install `archstone@rc` in a consumer project and import from both `archstone/core` and `archstone/domain/enterprise` — no private property conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)