### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,16 @@ test("example", () => {
 
 `@/` resolves to `src/` — use it for all internal imports.
 
+Always import from the **entry-point index**, never from deep file paths. Deep imports cause the dts bundler to inline type declarations into each sub-path bundle, which breaks TypeScript's nominal typing when a consumer mixes sub-path imports.
+
 ```ts
-import { Either } from "@/core/either"
-import { Entity } from "@/domain/enterprise/entities/entity"
+// ✅ correct — import from entry-point index
+import { Either } from "@/core/index.ts"
+import { UniqueEntityId } from "@/core/index.ts"
+
+// ❌ wrong — deep path causes dts inlining and type conflicts
+import { Either } from "@/core/either.ts"
+import { UniqueEntityId } from "@/core/unique-entity-id.ts"
 ```
 
 ## Gotchas
@@ -71,6 +78,7 @@ Sharp edges that have caused real issues — check these before assuming a bug:
 - `clearEvents()` is called internally by `dispatchEventsForAggregate` — never call it manually
 - `EventHandler` is an interface — `implements EventHandler`, not `extends`
 - `bun publish` does not add `node_modules/.bin` to PATH for lifecycle scripts — use `bunx <binary>` in scripts
+- Internal imports must use entry-point indices (`@/core/index.ts`), not deep paths — deep paths cause the dts bundler to inline type declarations into each sub-path bundle, which breaks TypeScript's nominal typing for types with `private` fields (e.g. `UniqueEntityId`) when consumers mix sub-path imports
 
 ## Agent Skills
 

--- a/README.md
+++ b/README.md
@@ -211,10 +211,13 @@ export interface AuditRepository extends Creatable<AuditLog> {}
 
 | Import | Contents |
 |---|---|
+| `archstone` | Everything |
 | `archstone/core` | `Either`, `ValueObject`, `UniqueEntityId`, `WatchedList`, `Optional` |
 | `archstone/domain` | All domain exports |
 | `archstone/domain/enterprise` | `Entity`, `AggregateRoot`, `DomainEvent`, `DomainEvents`, `EventHandler` |
 | `archstone/domain/application` | `UseCase`, `UseCaseError`, repository contracts |
+
+All sub-paths share type declarations via a common chunk — mixing imports from multiple sub-paths is fully type-safe with no duplicate declaration conflicts.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "archstone",
   "description": "TypeScript architecture foundation for backend services based on Domain-Driven Design and Clean Architecture",
-  "version": "1.2.1-rc.0",
+  "version": "1.2.1",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
## Summary

- Bumps version to `1.2.1` (promotes `1.2.1-rc.0` to stable)
- Updates `CLAUDE.md` with entry-point import rule and new gotcha
- Updates `README.md` Package Exports table with root entry and sub-path type safety note

## What's in this release

Fix for `Types have separate declarations of a private property 'value'` when importing from multiple sub-paths — landed in the dts fix PR (#28), validated via `archstone@1.2.1-rc.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)