### PR TITLE
fix: support multiline tag messages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Get tag message
         id: tag_message
-        run: echo "body=$(git tag -l --format='%(contents)' ${{ github.ref_name }})" >> $GITHUB_OUTPUT
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          git tag -l --format='%(contents)' ${{ github.ref_name }} >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem

The `Get tag message` step used `echo "body=..."` which only works for single-line content. Multiline tag messages (like `v1.2.1`) caused the workflow to fail with:

> *Invalid format '- Bump version to 1.2.1'*

## Fix

Switch to GitHub Actions' heredoc delimiter syntax for multiline output:

\`\`\`yaml
echo "body<<EOF" >> $GITHUB_OUTPUT
git tag -l --format='%(contents)' ... >> $GITHUB_OUTPUT
echo "EOF" >> $GITHUB_OUTPUT
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)