### PR TITLE
chore: merge CI into run-ci.yml with parallel jobs

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -1,27 +1,36 @@
 name: Continuous Integration
+
 on:
   pull_request:
     branches: [main]
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
       - name: Install dependencies
         run: bun install
+
       - name: Lint
         run: bun x ultracite check
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
       - name: Install dependencies
         run: bun install
+
       - name: Test
         run: bun test


### PR DESCRIPTION
## Summary

- Replaces `ci.yml` with `run-ci.yml` that runs `lint` and `test` as separate parallel jobs
- Removes the `push` trigger — CI now only runs on `pull_request` to `main` to avoid duplicate runs when commits land on a PR branch

## Test plan
- [ ] Verify the workflow appears under Actions on next PR
- [ ] Confirm lint and test jobs run in parallel