### PR TITLE
chore: add publish.yml with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish package to NPM
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.14'
+
+      - name: Update npm to support OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to NPM
+        run: npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     "prepublishOnly": "bun run build",
     "prepare": "bunx husky"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "type": "module",
   "types": "./dist/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` triggered on `v*.*.*` tags, using npm OIDC Trusted Publisher (provenance) — no `registry-url` in `setup-node` to avoid `_authToken` injection that blocks OIDC
- Adds `publishConfig` to `package.json` declaring the npm registry and `"access": "public"`
- Requires a GitHub environment named `npm` to be configured with the Trusted Publisher on npmjs.com

## Test plan
- [ ] Configure npm Trusted Publisher on npmjs.com pointing to this repo / `publish.yml` workflow
- [ ] Create a `v*.*.*` tag and verify the workflow triggers and publishes successfully with provenance