### PR TITLE
chore: add claude-review.yml for automated PR code review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,35 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          track_progress: true
+          prompt: |
+            Review the changes in this PR for `archstone`, a zero-dependency TypeScript library providing DDD and Clean Architecture primitives.
+            Focus only on real issues and relevant suggestions — no descriptions of what the code does.
+            Check for:
+            - Type safety: incorrect generics, unsafe casts, missing constraints, `any` leakage
+            - Layer violations: inner layers (core, enterprise) must never import from outer layers (application)
+            - API consistency: entity/aggregate identity, value object immutability, domain event dispatch
+            - Import rules: always import from a layer's index, never from deep file paths
+            - Test quality: missing edge cases, weak assertions, untested error paths
+            Use `gh pr comment` for general feedback. Use inline comments for specific line-level issues.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-review.yml` that triggers on every PR open/update/reopen
- Review is `continue-on-error: true` — informational only, never blocks merge
- Prompt is tailored to `archstone`: checks layer violations, import rules, type safety, domain primitives, and test quality
- Requires a `CLAUDE_CODE_OAUTH_TOKEN` repository secret to be configured

## Test plan
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` secret in repository settings
- [ ] Open a PR and verify Claude posts a review comment