### PR TITLE
chore: split claude-review into 3 jobs with CI gate

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,8 +7,66 @@ on:
       - 'src/**'
 
 jobs:
-  review:
+  wait-for-ci:
     if: ${{ !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    runs-on: ubuntu-latest
+    outputs:
+      conclusion: ${{ steps.poll.outputs.conclusion }}
+      run-id: ${{ steps.poll.outputs.run-id }}
+    steps:
+      - name: Wait for CI
+        id: poll
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          for i in $(seq 1 20); do
+            echo "Attempt $i/20..."
+            RUN=$(gh run list --repo "$REPO" --workflow "Continuous Integration" --commit "$SHA" --json databaseId,conclusion,status --limit 1 | jq -r '.[0] // empty')
+            if [ -n "$RUN" ]; then
+              STATUS=$(echo "$RUN" | jq -r '.status')
+              CONCLUSION=$(echo "$RUN" | jq -r '.conclusion')
+              RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
+              if [ "$STATUS" = "completed" ]; then
+                echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
+                echo "run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+            sleep 30
+          done
+          echo "conclusion=timed_out" >> "$GITHUB_OUTPUT"
+          echo "run-id=" >> "$GITHUB_OUTPUT"
+
+  notify-failure:
+    needs: wait-for-ci
+    if: ${{ needs.wait-for-ci.outputs.conclusion != 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post failure comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          CONCLUSION: ${{ needs.wait-for-ci.outputs.conclusion }}
+          RUN_ID: ${{ needs.wait-for-ci.outputs.run-id }}
+        run: |
+          if [ "$CONCLUSION" = "timed_out" ]; then
+            BODY="> [!WARNING]
+          > CI did not complete within 10 minutes — Claude review skipped."
+          else
+            FAILED_JOBS=$(gh run view "$RUN_ID" --repo "$REPO" --json jobs | jq -r '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+            BODY="> [!CAUTION]
+          > CI failed — Claude review paused. Failed jobs: $FAILED_JOBS"
+          fi
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+
+  review:
+    needs: wait-for-ci
+    if: ${{ needs.wait-for-ci.outputs.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,22 +74,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-          track_progress: true
           prompt: |
-            Review the changes in this PR for `archstone`, a zero-dependency TypeScript library providing DDD and Clean Architecture primitives.
-            Focus only on real issues and relevant suggestions — no descriptions of what the code does.
-            Check for:
-            - Type safety: incorrect generics, unsafe casts, missing constraints, `any` leakage
-            - Layer violations: inner layers (core, enterprise) must never import from outer layers (application)
-            - API consistency: entity/aggregate identity, value object immutability, domain event dispatch
-            - Import rules: always import from a layer's index, never from deep file paths
-            - Test quality: missing edge cases, weak assertions, untested error paths
-            Use `gh pr comment` for general feedback. Use inline comments for specific line-level issues.
+            You are a first-pass assistant for the maintainer of this library. Read README.md for general context and CLAUDE.md for conventions.
+
+            Your goal is to give the maintainer a brief, useful summary before they do their own review — not to replace it. Describe what this PR actually changes and why it matters, then flag anything that deserves closer attention: questionable design choices, risky areas, or anything that looks out of place. CI already handles correctness mechanically, so skip what tools catch.
+
+            Be brief and to the point — only include what genuinely helps the maintainer. Use `gh pr comment` to post it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,26 @@ The library is published to npm as `archstone` and exposes four entry points:
 | `archstone/domain/enterprise` | domain model primitives |
 | `archstone/domain/application` | orchestration contracts |
 
+### Claude Review Workflow
+
+`claude-review.yml` has 3 jobs: `wait-for-ci` (polls CI up to 10 min), `notify-failure` (posts PR comment on CI failure/timeout), `review` (runs Claude after CI passes).
+- Do NOT change the trigger to `workflow_run` — `track_progress` breaks in that mode (`AutomationContext` has no `entityNumber`)
+- Test the pre-commit hook with `sh .husky/pre-commit`, not `bun x husky`
+
+### Multiple PRs in One Session
+
+When creating several PRs at once, stack them so each branch starts from the previous one — not all from `main`. This avoids the "branch not up to date" cycle on sequential merges.
+
+```bash
+git checkout -b pr-1 && git add <files> && git commit && git push
+gh pr create --head pr-1 --base main
+
+git checkout -b pr-2 && git add <files> && git commit && git push
+gh pr create --head pr-2 --base pr-1
+```
+
+Only stack when PRs are sequential and independent. If they touch the same files, resolve that before splitting.
+
 ## Logical Architecture
 
 Three layers, each with a strict dependency rule — inner layers never import outer ones:


### PR DESCRIPTION
## Summary
- Replace single-job `claude-review.yml` with a 3-job workflow: `wait-for-ci` → `notify-failure` / `review`
- `wait-for-ci`: polls "Continuous Integration" workflow by head SHA every 30s, up to 20 attempts (~10 min); outputs `conclusion` and `run-id`
- `notify-failure`: posts `[!WARNING]` on timeout or `[!CAUTION]` with failed job names when CI doesn't pass
- `review`: runs `claude-code-action@v1` only after CI succeeds; updated prompt focuses on summarising the PR for the maintainer rather than mechanical checks
- Add `### Claude Review Workflow` and `### Multiple PRs in One Session` sections to `CLAUDE.md`

## Test plan
- [ ] Open a PR as a non-member — `wait-for-ci` should poll and unblock `review` once CI passes
- [ ] Simulate a CI failure — `notify-failure` should post a caution comment with the failed job name
- [ ] Verify `review` job is skipped when `wait-for-ci` concludes non-success

🤖 Generated with [Claude Code](https://claude.com/claude-code)