### PR TITLE
chore: use lightweight tag as fallback when tag message generation fails

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -53,9 +53,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if [ -n "$TAG_MESSAGE" ]; then
-            echo "$TAG_MESSAGE" > /tmp/tag-message.txt
-            git tag -a "v$VERSION" -F /tmp/tag-message.txt
+            git tag -a "v$VERSION" -m "${TAG_MESSAGE}"
           else
-            git tag -a "v$VERSION" -m " "
+            git tag "v$VERSION"
           fi
           git push origin "v$VERSION"


### PR DESCRIPTION
## Summary
- Use `git tag -a` with `-m` directly instead of a temp file when message is present
- Fall back to a lightweight `git tag` (no `-a`, no message) when generation fails, instead of an annotated tag with a blank message

🤖 Generated with [Claude Code](https://claude.com/claude-code)